### PR TITLE
Fixed adjusting frequency to the step, when tuning (SSB not fixed yet).

### DIFF
--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -3017,10 +3017,10 @@ void loop() {
 #endif
 
       // G8PTN: Used in place of rx.frequencyUp() and rx.frequencyDown()
-      if (currentMode == FM)
-        currentFrequency += tabFmStep[currentStepIdx] * encoderCount;       // FM Up/Down
-      else
-        currentFrequency += tabAmStep[currentStepIdx] * encoderCount;       // AM Up/Down
+      uint16_t step = currentMode == FM ? tabFmStep[currentStepIdx] : tabAmStep[currentStepIdx]; 
+      uint16_t stepAdjust = currentFrequency % step;
+      step = !stepAdjust? step : encoderCount>0? step - stepAdjust : stepAdjust;
+      currentFrequency += step * encoderCount;
 
       // Band limit checking
       uint16_t bMin = band[bandIdx].minimumFreq;                            // Assign lower band limit

--- a/changelog/30.added.md
+++ b/changelog/30.added.md
@@ -1,0 +1,1 @@
++ Now aligning frequency to the step when tuning in AM and FM modes.


### PR DESCRIPTION
This change will adjust the AM/FM frequency to the current step when tuning. In other words, if the current frequency is 6666 and the step is 5, then tuning one step up will bring it to 6670 while tuning one step down will end up with 6665. Once adjusted, the frequency will tune normally, in the increments of 5.

SSB frequency is changed in a completely different way. I have not been able to make it work so far.