### PR TITLE
Change to optional RDS clock

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+; EditorConfig is awesome: http://EditorConfig.org
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.c]
+indent_style = space
+indent_size = 2
+
+[*.h]
+indent_style = space
+indent_size = 2
+
+[*.ino]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/ats-mini/Makefile
+++ b/ats-mini/Makefile
@@ -10,7 +10,7 @@ PORT := /dev/cu.usbmodem1101
 
 INO = ats-mini.ino
 SRC = $(INO) Rotary.cpp
-HEADERS = User_Setup.h Rotary.h patch_init.h
+HEADERS = tft_setup.h themes.h Rotary.h patch_init.h
 ELF = ./build/$(FQBN)/$(INO).elf
 
 all: build

--- a/ats-mini/tft_setup.h
+++ b/ats-mini/tft_setup.h
@@ -1,2 +1,1 @@
 #include <User_Setups/Setup206_LilyGo_T_Display_S3.h>     // For the LilyGo T-Display S3 based ESP32S3 with ST7789 170 x 320 TFT
-

--- a/changelog/39.added.md
+++ b/changelog/39.added.md
@@ -1,0 +1,1 @@
+- Added option to set on/off RDS clock in settings.

--- a/changelog/39.removed.md
+++ b/changelog/39.removed.md
@@ -1,0 +1,1 @@
+- Removed the confusable Z letter from time.


### PR DESCRIPTION
1. Added option to on/off RDS clock in settings.
2. Removed the confusable `Z` letter from time.
3. Fixed small bugs and refactoring of code.
4. Fixed Makefile.
5. Removed unusable tail spaces.
6. Added `.editorconfig` file.

I'm going to add the support of timezones for RDS clock. It will be based on this PR.