### PR TITLE
Add Fm region (De-Emphasis Time Constant) setting

### DIFF
--- a/ats-mini/Common.h
+++ b/ats-mini/Common.h
@@ -105,6 +105,14 @@ typedef struct
   const char *city;       // City name
 } UTCOffset;
 
+typedef struct
+{
+  // From https://www.skyworksinc.com/-/media/Skyworks/SL/documents/public/application-notes/AN332.pdf
+  // Property 0x1100. FM_DEEMPHASIS
+  uint8_t value;
+  const char* desc;
+} FMRegion;
+
 //
 // Global Variables
 //
@@ -141,6 +149,7 @@ extern int8_t AmSoftMuteIdx;
 extern int8_t SsbSoftMuteIdx;
 extern uint8_t rdsModeIdx;
 extern uint8_t wifiModeIdx;
+extern uint8_t FmRegionIdx;
 
 extern int8_t agcIdx;
 extern int8_t agcNdx;

--- a/ats-mini/Menu.cpp
+++ b/ats-mini/Menu.cpp
@@ -486,7 +486,7 @@ void doAvc(int dir)
 void doFmRegion(int dir)
 {
   // Only allow for FM mode
-  if(currentCmd!=FM) return;
+  if(currentMode!=FM) return;
 
   FmRegionIdx = wrap_range(FmRegionIdx, dir, 0, LAST_ITEM(fmRegions));
   rx.setFMDeEmphasis(fmRegions[FmRegionIdx].value);
@@ -1294,6 +1294,11 @@ static void drawFmRegion(int x, int y, int sx)
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
       spr.setTextColor(TH.menu_item, TH.menu_bg);
+    }
+
+    // Prevent repeats for short menus
+    if (count < 5 && (i < 0 || i >= count)) {
+      continue;
     }
 
     spr.setTextDatum(MC_DATUM);

--- a/ats-mini/Menu.cpp
+++ b/ats-mini/Menu.cpp
@@ -79,7 +79,6 @@ Band *getCurrentBand() { return(&bands[bandIdx]); }
 #define MENU_AVC          9
 #define MENU_SOFTMUTE    10
 #define MENU_SETTINGS    11
-#define MENU_FM_REGION   12
 
 int8_t menuIdx = MENU_VOLUME;
 
@@ -97,7 +96,6 @@ static const char *menu[] =
   "AVC",
   "SoftMute",
   "Settings",
-  "FM Region",
 };
 
 //
@@ -114,7 +112,8 @@ static const char *menu[] =
 #define MENU_SLEEP        7
 #define MENU_SLEEPMODE    8
 #define MENU_WIFIMODE     9
-#define MENU_ABOUT        10
+#define MENU_FM_REGION    10
+#define MENU_ABOUT        11
 
 int8_t settingsIdx = MENU_BRIGHTNESS;
 
@@ -130,6 +129,7 @@ static const char *settings[] =
   "Sleep",
   "Sleep Mode",
   "Wi-Fi",
+  "FM Region",
   "About",
 };
 
@@ -751,10 +751,6 @@ static void clickMenu(int cmd, bool shortPress)
       // No AVC in FM mode
       if(currentMode!=FM) currentCmd = CMD_AVC;
       break;
-    case MENU_FM_REGION:
-      // Only in FM mode
-      if(currentMode==FM) currentCmd = CMD_FM_REGION;
-      break;
   }
 }
 
@@ -782,6 +778,10 @@ static void clickSettings(int cmd, bool shortPress)
     case MENU_SLEEPMODE:  currentCmd = CMD_SLEEPMODE; break;
     case MENU_UTCOFFSET:  currentCmd = CMD_UTCOFFSET; break;
     case MENU_WIFIMODE:   currentCmd = CMD_WIFIMODE;  break;
+    case MENU_FM_REGION:
+      // Only in FM mode
+      if(currentMode==FM) currentCmd = CMD_FM_REGION;
+      break;
     case MENU_ABOUT:      currentCmd = CMD_ABOUT;     break;
   }
 }
@@ -1284,7 +1284,7 @@ static void drawAvc(int x, int y, int sx)
 
 static void drawFmRegion(int x, int y, int sx)
 {
-  drawCommon(menu[MENU_FM_REGION], x, y, sx, true);
+  drawCommon(settings[MENU_FM_REGION], x, y, sx, true);
 
   int count = ITEM_COUNT(fmRegions);
   for(int i=-2 ; i<3 ; i++)

--- a/ats-mini/Menu.cpp
+++ b/ats-mini/Menu.cpp
@@ -133,7 +133,7 @@ static const char *settings[] =
   "About",
 };
 
-// 
+//
 // FM Region Menu
 //
 const FMRegion fmRegions[] = {
@@ -488,7 +488,7 @@ void doFmRegion(int dir)
   // Only allow for FM mode
   if(currentCmd!=FM) return;
 
-  FmRegionIdx = wrap_range(FmRegionIdx, dir, 0, LAST_ITEM(fmRegion));
+  FmRegionIdx = wrap_range(FmRegionIdx, dir, 0, LAST_ITEM(fmRegions));
   rx.setFMDeEmphasis(fmRegions[FmRegionIdx].value);
 }
 

--- a/ats-mini/Menu.h
+++ b/ats-mini/Menu.h
@@ -72,7 +72,7 @@ extern Band bands[];
 extern Memory memories[];
 extern const UTCOffset utcOffsets[];
 extern const char *bandModeDesc[];
-extern const FMRegion fmRegions[]
+extern const FMRegion fmRegions[];
 extern int bandIdx;
 
 // These are menu commands

--- a/ats-mini/Menu.h
+++ b/ats-mini/Menu.h
@@ -26,7 +26,8 @@
 #define CMD_AVC       0x1800 // |
 #define CMD_MEMORY    0x1900 // |
 #define CMD_SEEK      0x1A00 // |
-#define CMD_SQUELCH   0x1B00 //-+
+#define CMD_SQUELCH   0x1B00 // |
+#define CMD_FM_REGION 0x1C00 //-+
 #define CMD_SETTINGS  0x2000 //-SETTINGS MODE starts here
 #define CMD_BRT       0x2100 // |
 #define CMD_CAL       0x2200 // |
@@ -71,6 +72,7 @@ extern Band bands[];
 extern Memory memories[];
 extern const UTCOffset utcOffsets[];
 extern const char *bandModeDesc[];
+extern const FMRegion fmRegions[]
 extern int bandIdx;
 
 // These are menu commands
@@ -107,6 +109,7 @@ const UTCOffset *getUTCOffset(uint8_t idx);
 void doSoftMute(int dir);
 void doAgc(int dir);
 void doAvc(int dir);
+void doFmRegion(int dir);
 void doBandwidth(int dir);
 void doVolume(int dir);
 void doBrt(int dir);

--- a/ats-mini/Menu.h
+++ b/ats-mini/Menu.h
@@ -26,8 +26,7 @@
 #define CMD_AVC       0x1800 // |
 #define CMD_MEMORY    0x1900 // |
 #define CMD_SEEK      0x1A00 // |
-#define CMD_SQUELCH   0x1B00 // |
-#define CMD_FM_REGION 0x1C00 //-+
+#define CMD_SQUELCH   0x1B00 //-+
 #define CMD_SETTINGS  0x2000 //-SETTINGS MODE starts here
 #define CMD_BRT       0x2100 // |
 #define CMD_CAL       0x2200 // |
@@ -39,7 +38,8 @@
 #define CMD_SLEEPMODE 0x2800 // |
 #define CMD_UTCOFFSET 0x2900 // |
 #define CMD_WIFIMODE  0x2A00 // |
-#define CMD_ABOUT     0x2B00 //-+
+#define CMD_FM_REGION 0x2B00 // |
+#define CMD_ABOUT     0x2C00 //-+
 
 //
 // Data Types

--- a/ats-mini/Storage.cpp
+++ b/ats-mini/Storage.cpp
@@ -114,7 +114,6 @@ void eepromSaveConfig()
   EEPROM.write(addr++, currentMode);        // Stores the current mode (FM / AM / LSB / USB). Now per mode, leave for compatibility
   EEPROM.write(addr++, currentBFOs >> 8);   // G8PTN: Stores the current BFO % 1000 (HIGH byte)
   EEPROM.write(addr++, currentBFOs & 0XFF); // G8PTN: Stores the current BFO % 1000 (LOW byte)
-  EEPROM.write(addr++, FmRegionIdx);        // Stores the current FM region value
   EEPROM.commit();
 
   // G8PTN: Commented out the assignment
@@ -165,6 +164,7 @@ void eepromSaveConfig()
   EEPROM.write(addr++, scrollDirection<0? 1:0);  // Stores the current Scroll setting
   EEPROM.write(addr++, utcOffsetIdx);            // Stores the current UTC Offset
   EEPROM.write(addr++, currentSquelch);          // Stores the current Squelch value
+  EEPROM.write(addr++, FmRegionIdx);             // Stores the current FM region value
   EEPROM.commit();
 
   addr = EEPROM_SETP_ADDR;
@@ -200,7 +200,6 @@ void eepromLoadConfig()
   currentMode = EEPROM.read(addr++);             // Reads stored mode. Now per mode, leave for compatibility
   currentBFO  = EEPROM.read(addr++) << 8;        // Reads stored BFO value (HIGH byte)
   currentBFO |= EEPROM.read(addr++);             // Reads stored BFO value (HIGH byte)
-  FmRegionIdx = EEPROM.read(addr++);             // Reads the current FM region value
 
   // Read current band settings
   for(int i=0 ; i<getTotalBands() ; i++)
@@ -240,6 +239,7 @@ void eepromLoadConfig()
   scrollDirection = EEPROM.read(addr++)? -1:1;   // Reads stored Scroll setting
   utcOffsetIdx   = EEPROM.read(addr++);          // Reads the current UTC Offset
   currentSquelch = EEPROM.read(addr++);          // Reads the current Squelch value
+  FmRegionIdx = EEPROM.read(addr++);             // Reads the current FM region value
 
   addr = EEPROM_SETP_ADDR;
   for(int i=0 ; i<getTotalBands() ; i++)

--- a/ats-mini/Storage.cpp
+++ b/ats-mini/Storage.cpp
@@ -114,6 +114,7 @@ void eepromSaveConfig()
   EEPROM.write(addr++, currentMode);        // Stores the current mode (FM / AM / LSB / USB). Now per mode, leave for compatibility
   EEPROM.write(addr++, currentBFOs >> 8);   // G8PTN: Stores the current BFO % 1000 (HIGH byte)
   EEPROM.write(addr++, currentBFOs & 0XFF); // G8PTN: Stores the current BFO % 1000 (LOW byte)
+  EEPROM.write(addr++, FmRegionIdx);        // Stores the current FM region value
   EEPROM.commit();
 
   // G8PTN: Commented out the assignment
@@ -199,6 +200,7 @@ void eepromLoadConfig()
   currentMode = EEPROM.read(addr++);             // Reads stored mode. Now per mode, leave for compatibility
   currentBFO  = EEPROM.read(addr++) << 8;        // Reads stored BFO value (HIGH byte)
   currentBFO |= EEPROM.read(addr++);             // Reads stored BFO value (HIGH byte)
+  FmRegionIdx = EEPROM.read(addr++);             // Reads the current FM region value
 
   // Read current band settings
   for(int i=0 ; i<getTotalBands() ; i++)

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -64,6 +64,7 @@ int8_t SsbSoftMuteIdx = 4;              // Default SSB = 4, range = 0 to 32
 uint8_t volume = DEFAULT_VOLUME;        // Volume, range = 0 (muted) - 63
 uint8_t currentSquelch = 0;             // Squelch, range = 0 (disabled) - 127
 bool squelchCutoff = false;             // True if the Squelch cutoff is in effect
+uint8_t FmRegionIdx = 0;                // FM Region
 
 uint16_t currentBrt = 130;              // Display brightness, range = 10 to 255 in steps of 5
 uint16_t currentSleep = DEFAULT_SLEEP;  // Display sleep timeout, range = 0 to 255 in steps of 5
@@ -275,7 +276,7 @@ void useBand(const Band *band)
     rx.setSeekFmRssiThreshold(5); // default is 20
     rx.setSeekFmSNRThreshold(3); // default is 3
 
-    rx.setFMDeEmphasis(1);
+    rx.setFMDeEmphasis(fmRegions[FmRegionIdx].value);
     rx.RdsInit();
     rx.setRdsConfig(1, 2, 2, 2, 2);
     rx.setGpioCtl(1, 0, 0);   // G8PTN: Enable GPIO1 as output

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -50,6 +50,7 @@ The menu can be invoked by clicking the encoder button and is closed automatical
 * **AVC** - Sets the maximum gain for automatic volume control (not applicable to FM mode).
 * **SoftMute** - Sets softmute max attenuation (only applicable to AM/SSB).
 * **Settings** - Settings submenu.
+* **FM Region** - FM Region setting. For setting FM de-emphasis time constant by region.
 
 ## Settings menu
 

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -50,7 +50,6 @@ The menu can be invoked by clicking the encoder button and is closed automatical
 * **AVC** - Sets the maximum gain for automatic volume control (not applicable to FM mode).
 * **SoftMute** - Sets softmute max attenuation (only applicable to AM/SSB).
 * **Settings** - Settings submenu.
-* **FM Region** - FM Region setting. For setting FM de-emphasis time constant by region.
 
 ## Settings menu
 
@@ -64,6 +63,7 @@ The menu can be invoked by clicking the encoder button and is closed automatical
 * **Sleep** - Automatic sleep interval in seconds (0 - disabled).
 * **Sleep Mode** - Locked - lock the encoder rotation during sleep; Unlocked - allow tuning the frequency in sleep mode; CPU Sleep - the maximum power saving mode. With the display being on, default brightness, and Wi-Fi the power consumption is about 170mA, without Wi-Fi 100mA, Locked/Unlocked modes draw about 70mA, CPU sleep mode draws about 40mA.
 * **Wi-Fi** - Wi-Fi mode: Off (default), Access Point, Access Point + Connect, Connect, Sync Only. More details on that below.
+* **FM Region** - FM Region setting. For setting FM de-emphasis time constant by region.
 * **About** - Informational screens (Help, Authors, System).
 
 ## Wi-Fi


### PR DESCRIPTION
Currently, the FM de-emphasis time constant setting is hardcoded as `1` which is 50uS according to section `Property 0x1100. FM_DEEMPHASIS` in the [datasheet](https://www.skyworksinc.com/-/media/Skyworks/SL/documents/public/application-notes/AN332.pdf).

This setting is suitable for many parts of the word, but not in the US (or North America) in general. For that, the correct setting is 75uS. Using 50uS results in a slightly bright sound (i.e. too much high frequencies, not enough low frequencies).

Especially when using headphones, the bass response is already not great, and this setting (where appropriate) makes it a bit better. 