### PR TITLE
Add mDNS responder

### DIFF
--- a/ats-mini/Network.cpp
+++ b/ats-mini/Network.cpp
@@ -147,6 +147,8 @@ void netStop()
 {
   wifi_mode_t mode = WiFi.getMode();
 
+  MDNS.end();
+
   // If network connection up, shut it down
   if((mode==WIFI_STA) || (mode==WIFI_AP_STA))
     WiFi.disconnect(true);
@@ -218,6 +220,7 @@ void netInit(uint8_t netMode, bool showStatus)
 
     // Initialize mDNS
     MDNS.begin("atsmini"); // Set the hostname to "atsmini.local"
+    MDNS.addService("http", "tcp", 80);
   }
 }
 

--- a/ats-mini/Network.cpp
+++ b/ats-mini/Network.cpp
@@ -11,6 +11,7 @@
 #include <ESPAsyncWebServer.h>
 #include <NTPClient.h>
 #include <Preferences.h>
+#include <ESPmDNS.h>
 
 #define CONNECT_TIME  3000  // Time of inactivity to start connecting WiFi
 
@@ -214,6 +215,16 @@ void netInit(uint8_t netMode, bool showStatus)
   {
     // Initialize web server for remote configuration
     webInit();
+
+    //Initialize mDNS
+    if (!MDNS.begin("atsmini")) 
+    {  // Set the hostname to "atsmini.local"
+      Serial.println("Error setting up MDNS responder!");
+    }
+    else 
+    {
+     Serial.println("mDNS responder started, listening on atsmini.local");
+    }
   }
 }
 

--- a/ats-mini/Network.cpp
+++ b/ats-mini/Network.cpp
@@ -216,15 +216,8 @@ void netInit(uint8_t netMode, bool showStatus)
     // Initialize web server for remote configuration
     webInit();
 
-    //Initialize mDNS
-    if (!MDNS.begin("atsmini")) 
-    {  // Set the hostname to "atsmini.local"
-      Serial.println("Error setting up MDNS responder!");
-    }
-    else 
-    {
-     Serial.println("mDNS responder started, listening on atsmini.local");
-    }
+    // Initialize mDNS
+    MDNS.begin("atsmini"); // Set the hostname to "atsmini.local"
   }
 }
 
@@ -271,7 +264,7 @@ static bool wifiInitAP()
 
   drawScreen(
     ("Use Access Point " + String(apSSID)).c_str(),
-    ("IP : " + WiFi.softAPIP().toString()).c_str()
+    ("IP : " + WiFi.softAPIP().toString() + " or atsmini.local").c_str()
   );
 
   ajaxInterval = 2500;
@@ -336,7 +329,7 @@ static bool wifiConnect()
     // WiFi connection succeeded
     drawScreen(
       ("Connected to WiFi network (" + WiFi.SSID() + ")").c_str(),
-      ("IP : " + WiFi.localIP().toString()).c_str()
+      ("IP : " + WiFi.localIP().toString() + " or atsmini.local").c_str()
     );
     // Done
     ajaxInterval = 1000;

--- a/changelog/145.added.md
+++ b/changelog/145.added.md
@@ -1,0 +1,1 @@
+Allow connecting to the receiver's web UI using the atsmini.local mDNS name in addition to an IP address.

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -102,12 +102,12 @@ Initial configuration:
 
 * Enable the **AP Only** mode (the receiver will briefly display its 10.1.1.1 IP address).
 * Connect to the `ATS-Mini` access point from your phone or computer. There is no internet connection available on this access point. When connecting from a phone, it might be necessary to switch off the mobile data connection and any VPN/firewall software.
-* Open a browser and visit the following URL: <http://10.1.1.1>. The status web page should open.
+* Open a browser and visit the following URL: <http://10.1.1.1>. The status web page should open. Alternatively, you can try the mDNS address <atsmini.local> in your browser.
 * Click the `Config` link. Here you can add optional login and password to protect the settings page, configure up to three access points the receiver will try to connect to, and set a time zone and other settings.
 * After that, switch the Wi-Fi mode to **AP+Connect** or **Connect** (the receiver will briefly show its new dynamic IP address it got from a configured access point).
 * Now connect your phone/computer to the same access point and open the new URL to check whether the receiver connected to the internet.
 
-From now on you can switch the modes as you want and connect to your receiver either via the `ATS-Mini` internal access point (if enabled, mostly useful when there are no access points around), or via an external access point and a dynamic IP address.
+From now on you can switch the modes as you want and connect to your receiver either via the `ATS-Mini` internal access point (if enabled, mostly useful when there are no access points around), or via an external access point and a dynamic IP address. The receiver will always listen on the mDNS address <atsmini.local>.
 
 ```{hint}
 When on the go, you can set up a mobile Wi-Fi hotspot on your smartphone and use it to connect the receiver to the internet.


### PR DESCRIPTION
Hi!

Just a little addition. mDNS is now widely supported on major browsers. It aids accessing the webserver by simple using "atsmini.local" as the address, instead of remembering/searching for the current IP address at the current LAN. 