### PR TITLE
Spectrum Scan / Signal Survey first commit, no menu configurable

### DIFF
--- a/ats-mini/Common.h
+++ b/ats-mini/Common.h
@@ -137,6 +137,8 @@ extern uint16_t currentBrt;
 extern uint16_t currentSleep;
 extern uint8_t sleepModeIdx;
 extern bool zoomMenu;
+extern bool spectrumScan;
+extern int8_t spectrumState;
 extern int8_t scrollDirection;
 extern uint8_t utcOffsetIdx;
 extern uint8_t uiLayoutIdx;

--- a/ats-mini/Storage.cpp
+++ b/ats-mini/Storage.cpp
@@ -196,6 +196,7 @@ void eepromSaveConfig()
   EEPROM.write(addr++, rdsModeIdx);              // Stores the current RDS Mode value
   EEPROM.write(addr++, sleepModeIdx);            // Stores the current Sleep Mode value
   EEPROM.write(addr++, (uint8_t)zoomMenu);       // Stores the current Zoom Menu setting
+  EEPROM.write(addr++, (uint8_t)spectrumScan);   // Stores the current Spectrum Scan/Signal Survey setting
   EEPROM.write(addr++, scrollDirection<0? 1:0);  // Stores the current Scroll setting
   EEPROM.write(addr++, utcOffsetIdx);            // Stores the current UTC Offset
   EEPROM.write(addr++, currentSquelch);          // Stores the current Squelch value
@@ -272,6 +273,7 @@ void eepromLoadConfig()
   rdsModeIdx     = EEPROM.read(addr++);          // Reads stored RDS Mode value
   sleepModeIdx   = EEPROM.read(addr++);          // Reads stored Sleep Mode value
   zoomMenu       = (bool)EEPROM.read(addr++);    // Reads stored Zoom Menu setting
+  spectrumScan   = (bool)EEPROM.read(addr++);    // Reads the current Spectrum Scan/Signal Survey setting
   scrollDirection = EEPROM.read(addr++)? -1:1;   // Reads stored Scroll setting
   utcOffsetIdx   = EEPROM.read(addr++);          // Reads the current UTC Offset
   currentSquelch = EEPROM.read(addr++);          // Reads the current Squelch value

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -74,6 +74,8 @@ uint16_t currentBrt = 130;              // Display brightness, range = 10 to 255
 uint16_t currentSleep = DEFAULT_SLEEP;  // Display sleep timeout, range = 0 to 255 in steps of 5
 long elapsedSleep = millis();           // Display sleep timer
 bool zoomMenu = false;                  // Display zoomed menu item
+bool spectrumScan = true;               // Do a spectrum scan/signal survey while drawing the scale
+int8_t spectrumState = 1;               // -1 = reset, 0 = requested, 1 = done
 int8_t scrollDirection = 1;             // Menu scroll direction
 
 // Background screen refresh
@@ -914,6 +916,17 @@ void loop()
   {
     if(currentCmd == CMD_NONE) needRedraw = true;
     background_timer = currentTime;
+  }
+
+  // Spectrum scan/signal survey control. We use elapsedSleep to request a spectrum scan after a time of having used a control. After 2 seconds, a scan is requested. The scanState flag is set to "reset" after the count has started again. It's only set to 0 "request" after 3 seconds.
+  // It may be confusing, this is designed so to avoid putting counter resets in another place on the code, it's all contained in this conditional block. 
+  if(((currentTime - elapsedSleep) > 2000) && (spectrumState == -1)) // If more than 2 sec have passed and the flag is in the "reset" state, request a new scan.
+  {
+    spectrumState = 0; //requested
+  }
+  else if(((currentTime - elapsedSleep) < 2000) && (spectrumState == 1)) // If NO more than 2 sec have passed and the flag is in the "done" state, issue a reset. This is to only trigger 1 scan per control input detected.
+  {
+    spectrumState = -1; //issue a reset
   }
 
   // Redraw screen if necessary


### PR DESCRIPTION
Hi!

As requested, here's my implementation of a spectrum scan.

- Scan gets triggered after 2 seconds of user input using the already existing Sleep timer. For this, a small conditional block is placed on the main loop at ats-mini.ino. It's implemented using a tri-state flag to avoid setting extra timer resets anywhere else on the main loop, as there are already too many.

- The scan is done in Draw.cpp on the scale drawing loop. It takes advantage on the existing loop to tune to each frequency as the old bars are being drawn.  The current tuning frequency is restored (tuned to) at the exit of the loop.

- To avoid loosing the bars when the scale gets redrawn, the RSSI values get stored in a C++ std::map key/value pair. If no key is stored for a particular frequency, the default constructor at the map initializes it to zero, thus drawing a point on the scale until a scan is done.

Hope you like it!

Humberto