### PR TITLE
Adds volume control to web configuration page

### DIFF
--- a/ats-mini/Common.h
+++ b/ats-mini/Common.h
@@ -183,6 +183,7 @@ float scanGetSNR(uint16_t freq);
 
 // Station.c
 const char *getStationName();
+const char *getStationNameFull();
 const char *getRadioText();
 const char *getProgramInfo();
 const char *getRdsTime();

--- a/ats-mini/Network.cpp
+++ b/ats-mini/Network.cpp
@@ -557,7 +557,6 @@ static const String webPage(const String &body)
   "<META NAME='viewport' CONTENT='width=device-width, initial-scale=1.0'>"
   "<TITLE>ATS-Mini Config</TITLE>"
   "<STYLE>" + webStyleSheet() + "</STYLE>"
-  "<LINK REL='STYLESHEET' HREF='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css'>" // TODO FIND A BETTER SOLUTION TO REDUCE SIZE
 "</HEAD>"
 "<BODY STYLE='font-family: sans-serif;'>" + body + "</BODY>"
 "</HTML>"

--- a/ats-mini/Station.cpp
+++ b/ats-mini/Station.cpp
@@ -208,8 +208,8 @@ static bool showRdsTime(const char *rdsTime)
   // If NTP time available, do not use RDS time
   if(!rdsTime || ntpIsAvailable()) return(false);
 
-  // The standard RDS time format is �HH:MM�.
-  // or sometimes more complex like �DD.MM.YY,HH:MM�.
+  // The standard RDS time format is “HH:MM”.
+  // or sometimes more complex like “DD.MM.YY,HH:MM”.
   const char *timeField = strstr(rdsTime, ":");
 
   // If we find a valid time format...

--- a/ats-mini/Station.cpp
+++ b/ats-mini/Station.cpp
@@ -77,6 +77,11 @@ const char *getStationName()
     return(getRDSMode() & RDS_PS? bufStationName : "");
 }
 
+const char *getStationNameFull()
+{
+    return bufStationName[0] ? (bufStationName[0] == 0xFF ? bufStationName + 1 : bufStationName) : "";
+}
+
 const char *getRadioText()
 {
   return(getRDSMode() & RDS_RT? bufRadioText : "");
@@ -203,8 +208,8 @@ static bool showRdsTime(const char *rdsTime)
   // If NTP time available, do not use RDS time
   if(!rdsTime || ntpIsAvailable()) return(false);
 
-  // The standard RDS time format is “HH:MM”.
-  // or sometimes more complex like “DD.MM.YY,HH:MM”.
+  // The standard RDS time format is ï¿½HH:MMï¿½.
+  // or sometimes more complex like ï¿½DD.MM.YY,HH:MMï¿½.
   const char *timeField = strstr(rdsTime, ":");
 
   // If we find a valid time format...


### PR DESCRIPTION
Enables volume adjustment via the web interface.

This update introduces a volume selector to the web configuration page, allowing users to set the receiver's volume level through a web browser. The selected volume is saved and applied to the receiver. It also adds a full station name getter.


<img width="818" height="519" alt="image" src="https://github.com/user-attachments/assets/e60331f3-374f-4e57-9a77-6010befe3840" />

<img width="932" height="558" alt="image" src="https://github.com/user-attachments/assets/2fcdd400-a7b7-4f64-b1d3-caa79ed35e28" />



<img width="1613" height="659" alt="image" src="https://github.com/user-attachments/assets/9fe3eb3e-bc8c-405b-8368-5741c032aff4" />
