### PR TITLE
Wake screen upon encoder rotation

### DIFF
--- a/ats-mini/Common.h
+++ b/ats-mini/Common.h
@@ -51,6 +51,7 @@
 #define ENCODER_PIN_A  2            // GPIO02
 #define ENCODER_PIN_B  1            // GPIO01
 #define ENCODER_PUSH_BUTTON 21      // GPIO21
+#define ENCODER_PIN_BITMASK(PIN) (1ULL << PIN)
 
 // Compute number of items in an array
 #define ITEM_COUNT(array) (sizeof(array) / sizeof((array)[0]))

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -710,9 +710,12 @@ void loop()
   int ble_event = bleDoCommand(bleModeIdx);
 
   // Block encoder rotation when in the locked sleep mode
-  if(encoderCount && sleepOn() && sleepModeIdx==SLEEP_LOCKED) {
-    encoderCount = 0;
-    sleepOn(!sleepOn());
+  if(encoderCount && sleepOn() && sleepModeIdx==SLEEP_LOCKED) encoderCount = 0;
+
+  // Don't wake in unlocked sleep mode
+  if(encoderCount && currentSleep && sleepOn() && sleepModeIdx!=SLEEP_UNLOCKED) {
+    sleepOn(false);
+    needRedraw = true;
   }
 
   // Activate push and rotate mode (can span multiple loop iterations until the button is released)

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -710,7 +710,10 @@ void loop()
   int ble_event = bleDoCommand(bleModeIdx);
 
   // Block encoder rotation when in the locked sleep mode
-  if(encoderCount && sleepOn() && sleepModeIdx==SLEEP_LOCKED) encoderCount = 0;
+  if(encoderCount && sleepOn() && sleepModeIdx==SLEEP_LOCKED) {
+    encoderCount = 0;
+    sleepOn(!sleepOn());
+  }
 
   // Activate push and rotate mode (can span multiple loop iterations until the button is released)
   if (encoderCount && pb1st.isPressed) pushAndRotate = true;


### PR DESCRIPTION
I found it absolutely terrible in terms of UX to wake the screen with encoder press. It feels much more natural to wake it with encoder rotation.

If we don't want it to be the only option, we can still make it an option via the settings menu.