### PR TITLE
Fix AVC wrapping to avoid selecting odd AVC values.

### DIFF
--- a/ats-mini/Menu.cpp
+++ b/ats-mini/Menu.cpp
@@ -564,16 +564,17 @@ void doAvc(int dir)
   // Only allow for AM and SSB modes
   if(currentMode==FM) return;
 
+  // wrap_range expects to wrap a range of incremental numbers. avc instead is a range of all even numbers
+  int8_t newAvcIdx = wrap_range((isSSB() ? SsbAvcIdx : AmAvcIdx) / 2, dir, 12 / 2, 90 / 2) * 2;
   if(isSSB())
   {
-    SsbAvcIdx = wrap_range(SsbAvcIdx, 2*dir, 12, 90);
-    rx.setAvcAmMaxGain(SsbAvcIdx);
+    SsbAvcIdx = newAvcIdx;
   }
   else
   {
-    AmAvcIdx = wrap_range(AmAvcIdx, 2*dir, 12, 90);
-    rx.setAvcAmMaxGain(AmAvcIdx);
+    AmAvcIdx = newAvcIdx;
   }
+  rx.setAvcAmMaxGain(newAvcIdx);
 }
 
 void doFmRegion(int dir)


### PR DESCRIPTION
When changing AVC from the menu and wrapping below/above the range 12-90 the value ends up on an odd value which shouldn't be allowed.

Now when lowering past 12:
![avc-before](https://github.com/user-attachments/assets/39e0133a-4385-483e-8c25-22621f3349cd)

With this fix when lowering past 12:
![avc-after](https://github.com/user-attachments/assets/d7706cf3-f4e5-479f-b3df-1b180c07711a)