### PR TITLE
Delay after Si4732 POWER_ON solves issue "Si4732 not detected"

### DIFF
--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -121,7 +121,7 @@ void setup()
   // Enable SI4732 VDD
   pinMode(PIN_POWER_ON, OUTPUT);
   digitalWrite(PIN_POWER_ON, HIGH);
-  delay(100);
+  delay(50);
 
   // The line below may be necessary to setup I2C pins on ESP32
   Wire.begin(ESP32_I2C_SDA, ESP32_I2C_SCL);

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -121,7 +121,7 @@ void setup()
   // Enable SI4732 VDD
   pinMode(PIN_POWER_ON, OUTPUT);
   digitalWrite(PIN_POWER_ON, HIGH);
-  delay(500);
+  delay(100);
 
   // The line below may be necessary to setup I2C pins on ESP32
   Wire.begin(ESP32_I2C_SDA, ESP32_I2C_SCL);

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -121,7 +121,7 @@ void setup()
   // Enable SI4732 VDD
   pinMode(PIN_POWER_ON, OUTPUT);
   digitalWrite(PIN_POWER_ON, HIGH);
-  delay(50);
+  delay(100);
 
   // The line below may be necessary to setup I2C pins on ESP32
   Wire.begin(ESP32_I2C_SDA, ESP32_I2C_SCL);

--- a/ats-mini/ats-mini.ino
+++ b/ats-mini/ats-mini.ino
@@ -121,6 +121,7 @@ void setup()
   // Enable SI4732 VDD
   pinMode(PIN_POWER_ON, OUTPUT);
   digitalWrite(PIN_POWER_ON, HIGH);
+  delay(500);
 
   // The line below may be necessary to setup I2C pins on ESP32
   Wire.begin(ESP32_I2C_SDA, ESP32_I2C_SCL);


### PR DESCRIPTION
The in the FB-group reported issue "Si4732 not detected" was solved on my radio by introducing a delay of 100ms after the SI4732's LDO is enabled. Probably the charging time for the buffer capacitor is too long for immediate i2c communication. A delay of 50ms also worked, but I would prefere some reserve.

[https://www.facebook.com/groups/629443686140117/permalink/735118855572599/](url)