### PR TITLE
Fix several typos

### DIFF
--- a/changelog/typos.fixed.md
+++ b/changelog/typos.fixed.md
@@ -1,0 +1,1 @@
+Fixed several typos and clarified Serial connection options

--- a/docs/source/flash.md
+++ b/docs/source/flash.md
@@ -82,10 +82,10 @@ Works on: Windows, macOS, Linux
 3. A new serial port should appear. On Windows check the USB Serial COM port in the Windows Device Manager, on macOS it will look like `/dev/tty.usbmodemXXXX`, on Linux like `/dev/ttyACMX`.
 3. Run **just one** of the two following commands (the first one uses three separate firmware files, the second one uses the single merged firmware file):
    ```shell
-   uvx --from esptool esptool.py --chip esp32s3 --port SERIAL_PORT --baud 921600 --before default_reset --after hard_reset write_flash  -z --flash_mode keep --flash_freq keep --flash_size keep 0x0 ats-mini.ino.bootloader.bin 0x8000 ats-mini.ino.partitions.bin 0x10000 ats-mini.ino.bin
+   uvx --from esptool esptool.py --chip esp32s3 --port SERIAL_PORT --baud 921600 --before default-reset --after hard-reset write_flash  -z --flash-mode keep --flash-freq keep --flash-size keep 0x0 ats-mini.ino.bootloader.bin 0x8000 ats-mini.ino.partitions.bin 0x10000 ats-mini.ino.bin
 
    # OR
 
-   uvx --from esptool esptool.py --chip esp32s3 --port SERIAL_PORT --baud 921600 --before default_reset --after hard_reset write_flash  -z --flash_mode keep --flash_freq keep --flash_size keep 0x0 ats-mini.ino.merged.bin
+   uvx --from esptool esptool.py --chip esp32s3 --port SERIAL_PORT --baud 921600 --before default-reset --after hard-reset write-flash  -z --flash-mode keep --flash-freq keep --flash-size keep 0x0 ats-mini.ino.merged.bin
    ```
 4. Check out the firmware version in Menu -> Settings -> About on the receiver.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -23,7 +23,7 @@ For a quick start, check out the [User Manual](manual.md) and the [Flashing Inst
 
 The receiver was designed by a Chinese engineer. His nickname is Sunnygold and he open sourced both hardware (board, 3d-printed and cnc-machined cases) and software. Initially, he didn't knew that the receiver was sold on AliExpress and became popular on YouTube and other communities. Then another Chinese developer Zooc joined him to help improve the firmware.
 
-This documentation and the corresponding [GitHub org](https://github.com/esp32-si4732) was created by Max Arnold (R9UCL) and is not official in any way. It is just a collection of notes, source code, plus the excellent docs made by Dave (G8PTN). It also documents [my own fork](https://github.com/esp32-si4732/ats-mini) that is heavily based on the alernative G8PTN firmware (see the full [changelog](changelog.md) here).
+This documentation and the corresponding [GitHub org](https://github.com/esp32-si4732) was created by Max Arnold (R9UCL) and is not official in any way. It is just a collection of notes, source code, plus the excellent docs made by Dave (G8PTN). It also documents [my own fork](https://github.com/esp32-si4732/ats-mini) that is heavily based on the alternative G8PTN firmware (see the full [changelog](changelog.md) here).
 
 ## Hardware and software
 

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -171,7 +171,9 @@ To reset the receiver settings (current band, frequency, favorite stations, down
 
 ## Serial interface
 
-A USB-serial interface is available to control and monitor the receiver. Use [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) or Picocom to connect to the serial port. Alernatively, open the following web terminal in Google Chrome: <https://www.serialterminal.com/>. A list of commands:
+A USB-serial interface is available to control and monitor the receiver. Use [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) or Picocom to connect to the serial port.
+Alternatively, open the following web terminal in Google Chrome: <https://www.serialterminal.com/>. A list of commands:
+[ESP32 documentation](https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32/get-started/establish-serial-connection.html#verify-serial-connection) notes that the default serial settings are 115200 8N1, though 9600 8N1 may be a bit more reliable.
 
 | Button       | Function            | Comments                                                                                     |
 |--------------|---------------------|----------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Add additional details for serial connection

Note about changes to `flash.md`:
When using the latest versions of esptool, the parameters which are changed here emit errors:

```
┌──[tom@magrathea]──[10:39:04]
└─▶ ~:% uvx --from esptool esptool.py --chip esp32s3 --port /dev/ttyACM1 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode keep --flash_freq keep --flash_size keep 0x0 /tmp/support/ats-mini-v2.30-ospi/ats-mini.ino.merged.bin                                                                                                 [Error: 1]
Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.
Warning: Deprecated: Option '--flash_mode' is deprecated. Use '--flash-mode' instead.
Warning: Deprecated: Option '--flash_freq' is deprecated. Use '--flash-freq' instead.
Warning: Deprecated: Option '--flash_size' is deprecated. Use '--flash-size' instead.
Warning: Deprecated: Choice 'default_reset' for option '--before' is deprecated. Use 'default-reset' instead.
Warning: Deprecated: Choice 'hard_reset' for option '--after' is deprecated. Use 'hard-reset' instead.
Warning: Deprecated: Command 'write_flash' is deprecated. Use 'write-flash' instead.
```

This change will update them to the non-deprecated options, to ensure forward compatibility.