### PR TITLE
Avoid drawing background color when drawing text

### DIFF
--- a/ats-mini/About.cpp
+++ b/ats-mini/About.cpp
@@ -26,9 +26,9 @@ static void drawAboutCommon(uint8_t arrow)
   if(arrow & 1) spr.fillTriangle(307, 12, 301, 8, 301, 16, TH.text_muted);
 
   spr.setTextDatum(TL_DATUM);
-  spr.setTextColor(TH.text_muted, TH.bg);
+  spr.setTextColor(TH.text_muted);
   spr.drawString(RECEIVER_DESC, 0, 0, 4);
-  spr.setTextColor(TH.text, TH.bg);
+  spr.setTextColor(TH.text);
   spr.drawString(getVersion(), 2, 25, 2);
 }
 

--- a/ats-mini/Battery.cpp
+++ b/ats-mini/Battery.cpp
@@ -79,7 +79,7 @@ bool drawBattery(int x, int y)
   spr.drawLine(x + 30, y + 6, x + 30, y + 9, TH.batt_border);
 
   spr.setTextDatum(TR_DATUM);
-  spr.setTextColor(TH.batt_voltage, TH.bg);
+  spr.setTextColor(TH.batt_voltage);
 
   if(switchThemeEditor())
   {

--- a/ats-mini/Draw.cpp
+++ b/ats-mini/Draw.cpp
@@ -76,7 +76,7 @@ bool drawWiFiStatus(const char *statusLine1, const char *statusLine2, int x, int
   {
     // Draw two lines of network status
     spr.setTextDatum(TC_DATUM);
-    spr.setTextColor(TH.rds_text, TH.bg);
+    spr.setTextColor(TH.rds_text);
     if(statusLine1) spr.drawString(statusLine1, x, y, 2);
     if(statusLine2) spr.drawString(statusLine2, x, y+17, 2);
     return(true);
@@ -94,7 +94,7 @@ void drawZoomedMenu(const char *text, bool force)
 
   spr.fillSmoothRoundRect(RDS_OFFSET_X - 72 + 1, RDS_OFFSET_Y - 3 + 1, 152, 26, 4, TH.menu_bg);
   spr.setTextDatum(TC_DATUM);
-  spr.setTextColor(TH.menu_item, TH.menu_bg);
+  spr.setTextColor(TH.menu_item);
   spr.drawString(text, RDS_OFFSET_X + 5, RDS_OFFSET_Y, 4);
   spr.drawSmoothRoundRect(RDS_OFFSET_X - 72, RDS_OFFSET_Y - 3, 4, 4, 154, 28, TH.menu_border, TH.menu_bg);
 }
@@ -116,11 +116,11 @@ void drawMessage(const char *msg)
 void drawBandAndMode(const char *band, const char *mode, int x, int y)
 {
   spr.setTextDatum(TC_DATUM);
-  spr.setTextColor(TH.band_text, TH.bg);
+  spr.setTextColor(TH.band_text);
   uint16_t band_width = spr.drawString(band, x, y);
 
   spr.setTextDatum(TL_DATUM);
-  spr.setTextColor(TH.mode_text, TH.bg);
+  spr.setTextColor(TH.mode_text);
   uint16_t mode_width = spr.drawString(mode, x + band_width / 2 + 12, y + 8, 2);
 
   spr.drawSmoothRoundRect(x + band_width / 2 + 7, y + 7, 4, 4, mode_width + 8, 17, TH.mode_border, TH.bg);
@@ -135,7 +135,7 @@ void drawRadioText(int y, int ymax)
 
   // Draw potentially multi-line radio text
   spr.setTextDatum(TC_DATUM);
-  spr.setTextColor(TH.rds_text, TH.bg);
+  spr.setTextColor(TH.rds_text);
   for(; *rt && (y<ymax) ; y+=17, rt+=strlen(rt)+1)
     spr.drawString(rt, 160, y, 2);
 
@@ -191,7 +191,7 @@ void drawFrequency(uint32_t freq, int x, int y, int ux, int uy, uint8_t hl)
   hl &= 0x7F;
 
   spr.setTextDatum(MR_DATUM);
-  spr.setTextColor(TH.freq_text, TH.bg);
+  spr.setTextColor(TH.freq_text);
 
   if(currentMode==FM)
   {
@@ -201,7 +201,7 @@ void drawFrequency(uint32_t freq, int x, int y, int ux, int uy, uint8_t hl)
     // FM frequency
     spr.drawFloat(freq/100.00, 2, x, y, 7);
     spr.setTextDatum(ML_DATUM);
-    spr.setTextColor(TH.funit_text, TH.bg);
+    spr.setTextColor(TH.funit_text);
     spr.drawString("MHz", ux, uy);
   }
   else
@@ -229,7 +229,7 @@ void drawFrequency(uint32_t freq, int x, int y, int ux, int uy, uint8_t hl)
     }
 
     // SSB/AM frequencies are measured in kHz
-    spr.setTextColor(TH.funit_text, TH.bg);
+    spr.setTextColor(TH.funit_text);
     spr.drawString("kHz", ux, uy);
   }
 
@@ -259,7 +259,7 @@ void drawScale(uint32_t freq)
   spr.drawLine(160, 130, 160, 169, TH.scale_pointer);
 
   spr.setTextDatum(MC_DATUM);
-  spr.setTextColor(TH.scale_text, TH.bg);
+  spr.setTextColor(TH.scale_text);
 
   // Extra frequencies to draw outside the screen boundaries
   // (ensures frequency numbers don't disappear at the edges)
@@ -344,7 +344,7 @@ void drawStereoIndicator(int x, int y, bool stereo)
 void drawStationName(const char *name, int x, int y)
 {
   spr.setTextDatum(TC_DATUM);
-  spr.setTextColor(TH.rds_text, TH.bg);
+  spr.setTextColor(TH.rds_text);
   spr.drawString(name, x, y, 4);
 }
 
@@ -354,7 +354,7 @@ void drawStationName(const char *name, int x, int y)
 void drawLongStationName(const char *name, int x, int y)
 {
   int width = spr.textWidth(name, 2);
-  spr.setTextColor(TH.rds_text, TH.bg);
+  spr.setTextColor(TH.rds_text);
 
   if((x + width) >= 320)
   {

--- a/ats-mini/Layout-Default.cpp
+++ b/ats-mini/Layout-Default.cpp
@@ -31,7 +31,7 @@ void drawLayoutDefault(const char *statusLine1, const char *statusLine2)
   if(switchThemeEditor())
   {
     spr.setTextDatum(TR_DATUM);
-    spr.setTextColor(TH.text_warn, TH.bg);
+    spr.setTextColor(TH.text_warn);
     spr.drawString(TH.name, 319, BATT_OFFSET_Y + 17, 2);
   }
 

--- a/ats-mini/Layout-SMeter.cpp
+++ b/ats-mini/Layout-SMeter.cpp
@@ -87,19 +87,32 @@ static void drawAltStereoIndicator(int x, int y, bool stereo = true)
 static void drawLargeSMeter(int rssi, int strength, int x, int y)
 {
   // S-Meter legend
-  for(int i=x; i<=x+15*16 + 2; i+=2) spr.drawPixel(i, 28+y, TH.scale_line);
   spr.setTextDatum(TC_DATUM);
-  spr.setTextColor(TH.scale_text, TH.bg);
+  spr.setTextColor(TH.scale_text);
 
+  int last_x = x;
   for(int i=0; i<16; i++)
   {
     if(i%2)
     {
-      if(i < 10)  spr.drawNumber(i, x+(i*15)-13, 20+y, 2);
-      if(i == 11) spr.drawString("+20", x+(i*15)-13, 20+y, 2);
-      if(i == 13) spr.drawString("+40", x+(i*15)-13, 20+y, 2);
-      if(i == 15) spr.drawString("+60", x+(i*15)-13, 20+y, 2);
+      int text_width = 0;
+      int text_x = x + (i * 15) - 13;
+      if(i < 10)  text_width = spr.drawNumber(i, text_x, 20+y, 2);
+      if(i == 11) text_width = spr.drawString("+20", text_x, 20+y, 2);
+      if(i == 13) text_width = spr.drawString("+40", text_x, 20+y, 2);
+      if(i == 15) text_width = spr.drawString("+60", text_x, 20+y, 2);
+
+      // Draw the dotted line from end of previous number to start of current number
+      for(int px=last_x; px<text_x-text_width/2; px++) {
+        if(~px & 1) spr.drawPixel(px, 28+y, TH.scale_line);
+      }
+      last_x = text_x + text_width/2;
     }
+  }
+
+  // Draw the remaining dotted line after the last number
+  for(int px=last_x; px <= x+15*16+2; px++) {
+    if(~px & 1) spr.drawPixel(px, 28+y, TH.scale_line);
   }
 
   spr.setTextDatum(BL_DATUM);

--- a/ats-mini/Layout-SMeter.cpp
+++ b/ats-mini/Layout-SMeter.cpp
@@ -57,7 +57,7 @@ static void drawSmallScale(uint32_t freq, int y)
   spr.fillCircle(scaleStart + (scaleEnd-scaleStart) * (freq - band->minimumFreq) / (band->maximumFreq - band->minimumFreq), y, 3, TH.scale_pointer);
 
   char lim[8];
-  spr.setTextColor(TH.scale_text, TH.bg);
+  spr.setTextColor(TH.scale_text);
   spr.setTextDatum(MC_DATUM);
   if(band->bandType==FM_BAND_TYPE)
     sprintf(lim, "%0.2f", band->minimumFreq/100.00);
@@ -119,7 +119,7 @@ static void drawLargeSMeter(int rssi, int strength, int x, int y)
 
 static void drawLargeSNMeter(int snr, int x, int y)
 {
-  spr.setTextColor(TH.scale_text, TH.bg);
+  spr.setTextColor(TH.scale_text);
   spr.setTextDatum(BL_DATUM);
   spr.drawString("N", x - 10, 12 + y, 2);
   spr.setTextDatum(BR_DATUM);
@@ -164,7 +164,7 @@ void drawLayoutSmeter(const char *statusLine1, const char *statusLine2)
   if(switchThemeEditor())
   {
     spr.setTextDatum(TR_DATUM);
-    spr.setTextColor(TH.text_warn, TH.bg);
+    spr.setTextColor(TH.text_warn);
     spr.drawString(TH.name, 319, BATT_OFFSET_Y + 17, 2);
   }
 

--- a/ats-mini/Layout-SMeter.cpp
+++ b/ats-mini/Layout-SMeter.cpp
@@ -104,7 +104,7 @@ static void drawLargeSMeter(int rssi, int strength, int x, int y)
 
       // Draw the dotted line from end of previous number to start of current number
       for(int px=last_x; px<text_x-text_width/2; px++) {
-        if(~px & 1) spr.drawPixel(px, 28+y, TH.scale_line);
+        if(px & 1) spr.drawPixel(px, 28+y, TH.scale_line);
       }
       last_x = text_x + text_width/2;
     }
@@ -112,7 +112,7 @@ static void drawLargeSMeter(int rssi, int strength, int x, int y)
 
   // Draw the remaining dotted line after the last number
   for(int px=last_x; px <= x+15*16+2; px++) {
-    if(~px & 1) spr.drawPixel(px, 28+y, TH.scale_line);
+    if(px & 1) spr.drawPixel(px, 28+y, TH.scale_line);
   }
 
   spr.setTextDatum(BL_DATUM);

--- a/ats-mini/Menu.cpp
+++ b/ats-mini/Menu.cpp
@@ -992,7 +992,7 @@ static void drawCommon(const char *title, int x, int y, int sx, bool cursor = fa
 {
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_hdr, TH.menu_bg);
+  spr.setTextColor(TH.menu_hdr);
   spr.fillSmoothRoundRect(1+x, 1+y, 76+sx, 110, 4, TH.menu_border);
   spr.fillSmoothRoundRect(2+x, 2+y, 74+sx, 108, 4, TH.menu_bg);
 
@@ -1000,7 +1000,7 @@ static void drawCommon(const char *title, int x, int y, int sx, bool cursor = fa
   spr.drawLine(1+x, 23+y, 76+sx, 23+y, TH.menu_border);
 
   spr.setTextFont(0);
-  spr.setTextColor(TH.menu_item, TH.menu_bg);
+  spr.setTextColor(TH.menu_item);
   if(cursor)
     spr.fillRoundRect(6+x, 24+y+(2*16), 66+sx, 16, 2, TH.menu_hl_bg);
 }
@@ -1011,13 +1011,13 @@ static void drawMenu(int x, int y, int sx)
 
   spr.fillSmoothRoundRect(1+x, 1+y, 76+sx, 110, 4, TH.menu_border);
   spr.fillSmoothRoundRect(2+x, 2+y, 74+sx, 108, 4, TH.menu_bg);
-  spr.setTextColor(TH.menu_hdr, TH.menu_bg);
+  spr.setTextColor(TH.menu_hdr);
 
   spr.drawString("Menu", 40+x+(sx/2), 12+y, 2);
   spr.drawLine(1+x, 23+y, 76+sx, 23+y, TH.menu_border);
 
   spr.setTextFont(0);
-  spr.setTextColor(TH.menu_item, TH.menu_bg);
+  spr.setTextColor(TH.menu_item);
   spr.fillRoundRect(6+x, 24+y+(2*16), 66+sx, 16, 2, TH.menu_hl_bg);
 
   int count = ITEM_COUNT(menu);
@@ -1027,7 +1027,7 @@ static void drawMenu(int x, int y, int sx)
       drawZoomedMenu(menu[abs((menuIdx+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
     spr.setTextDatum(MC_DATUM);
     spr.drawString(menu[abs((menuIdx+count+i)%count)], 40+x+(sx/2), 64+y+(i*16), 2);
@@ -1040,12 +1040,12 @@ static void drawSettings(int x, int y, int sx)
 
   spr.fillSmoothRoundRect(1+x, 1+y, 76+sx, 110, 4, TH.menu_border);
   spr.fillSmoothRoundRect(2+x, 2+y, 74+sx, 108, 4, TH.menu_bg);
-  spr.setTextColor(TH.menu_hdr, TH.menu_bg);
+  spr.setTextColor(TH.menu_hdr);
   spr.drawString("Settings", 40+x+(sx/2), 12+y, 2);
   spr.drawLine(1+x, 23+y, 76+sx, 23+y, TH.menu_border);
 
   spr.setTextFont(0);
-  spr.setTextColor(TH.menu_item, TH.menu_bg);
+  spr.setTextColor(TH.menu_item);
   spr.fillRoundRect(6+x, 24+y+(2*16), 66+sx, 16, 2, TH.menu_hl_bg);
 
   int count = ITEM_COUNT(settings);
@@ -1055,7 +1055,7 @@ static void drawSettings(int x, int y, int sx)
       drawZoomedMenu(settings[abs((settingsIdx+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1074,7 +1074,7 @@ static void drawMode(int x, int y, int sx)
       drawZoomedMenu(bandModeDesc[abs((currentMode+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1096,7 +1096,7 @@ static void drawStep(int x, int y, int sx)
       drawZoomedMenu(steps[currentMode][abs((idx+i)%count)].desc);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1124,9 +1124,9 @@ static void drawScan(int x, int y, int sx)
 {
   drawCommon(menu[MENU_SCAN], x, y, sx);
   spr.setTextDatum(MC_DATUM);
-  spr.setTextColor(TH.scan_rssi, TH.menu_bg);
+  spr.setTextColor(TH.scan_rssi);
   spr.drawString("S", 40+x+(sx/2)-30, 66+y+30, 2);
-  spr.setTextColor(TH.scan_snr, TH.menu_bg);
+  spr.setTextColor(TH.scan_snr);
   spr.drawString("N", 40+x+(sx/2)+30, 66+y+30, 2);
 
   spr.drawSmoothArc(40+x+(sx/2), 66+y, 30, 27, 45, 180, TH.menu_param, TH.menu_bg);
@@ -1151,7 +1151,7 @@ static void drawBand(int x, int y, int sx)
       drawZoomedMenu(bands[abs((bandIdx+count+i)%count)].bandName);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1172,7 +1172,7 @@ static void drawBandwidth(int x, int y, int sx)
       drawZoomedMenu(bandwidths[currentMode][abs((idx+i)%count)].desc);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1191,7 +1191,7 @@ static void drawSleepMode(int x, int y, int sx)
       drawZoomedMenu(sleepModeDesc[abs((sleepModeIdx+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1210,7 +1210,7 @@ static void drawBleMode(int x, int y, int sx)
       drawZoomedMenu(bleModeDesc[abs((bleModeIdx+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     // Prevent repeats for short menus
@@ -1234,7 +1234,7 @@ static void drawWiFiMode(int x, int y, int sx)
       drawZoomedMenu(wifiModeDesc[abs((wifiModeIdx+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1253,7 +1253,7 @@ static void drawTheme(int x, int y, int sx)
       drawZoomedMenu(theme[abs((themeIdx+count+i)%count)].name);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1272,7 +1272,7 @@ static void drawUILayout(int x, int y, int sx)
       drawZoomedMenu(uiLayoutDesc[abs((uiLayoutIdx+count+i)%count)]);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     // Prevent repeats for short menus
@@ -1296,7 +1296,7 @@ static void drawRDSMode(int x, int y, int sx)
       drawZoomedMenu(rdsMode[abs((rdsModeIdx+count+i)%count)].desc);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1320,7 +1320,7 @@ static void drawUTCOffset(int x, int y, int sx)
     }
     else
     {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1354,7 +1354,7 @@ static void drawMemory(int x, int y, int sx)
       drawZoomedMenu(text);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     spr.setTextDatum(MC_DATUM);
@@ -1368,7 +1368,7 @@ static void drawVolume(int x, int y, int sx)
   drawZoomedMenu(menu[MENU_VOLUME]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   spr.drawNumber(volume, 40+x+(sx/2), 66+y, 7);
 
   if(muteOn(MUTE_MAIN))
@@ -1385,7 +1385,7 @@ static void drawAgc(int x, int y, int sx)
   drawCommon(menu[MENU_AGC_ATT], x, y, sx);
   drawZoomedMenu(menu[MENU_AGC_ATT]);
   spr.setTextDatum(MC_DATUM);
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
 
   // G8PTN: Read back value is not used
   // rx.getAutomaticGainControl();
@@ -1427,7 +1427,7 @@ static void drawSoftMuteMaxAtt(int x, int y, int sx)
   drawZoomedMenu(menu[MENU_SOFTMUTE]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   spr.drawString("Max Attn", 40+x+(sx/2), 32+y, 2);
   spr.drawNumber(softMuteMaxAttIdx, 40+x+(sx/2), 60+y, 4);
   spr.drawString("dB", 40+x+(sx/2), 90+y, 4);
@@ -1439,7 +1439,7 @@ static void drawCal(int x, int y, int sx)
   drawZoomedMenu(settings[MENU_CALIBRATION]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   if (currentMode == USB)
   {
     spr.drawString("USB", 40+x+(sx/2), 35+y, 2);
@@ -1462,7 +1462,7 @@ static void drawAvc(int x, int y, int sx)
   drawZoomedMenu(menu[MENU_AVC]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   spr.drawString("Max Gain", 40+x+(sx/2), 32+y, 2);
 
   // Only show AVC for AM and SSB modes
@@ -1485,7 +1485,7 @@ static void drawFmRegion(int x, int y, int sx)
       drawZoomedMenu(fmRegions[abs((FmRegionIdx+count+i)%count)].desc);
       spr.setTextColor(TH.menu_hl_text, TH.menu_hl_bg);
     } else {
-      spr.setTextColor(TH.menu_item, TH.menu_bg);
+      spr.setTextColor(TH.menu_item);
     }
 
     // Prevent repeats for short menus
@@ -1504,7 +1504,7 @@ static void drawBrt(int x, int y, int sx)
   drawZoomedMenu(settings[MENU_BRIGHTNESS]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   spr.drawNumber(currentBrt, 40+x+(sx/2), 60+y, 4);
 }
 
@@ -1514,7 +1514,7 @@ static void drawSleep(int x, int y, int sx)
   drawZoomedMenu(settings[MENU_SLEEP]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   spr.drawNumber(currentSleep, 40+x+(sx/2), 60+y, 4);
 }
 
@@ -1524,7 +1524,7 @@ static void drawZoom(int x, int y, int sx)
   drawZoomedMenu(settings[MENU_ZOOM]);
   spr.setTextDatum(MC_DATUM);
 
-  spr.setTextColor(TH.menu_param, TH.menu_bg);
+  spr.setTextColor(TH.menu_param);
   spr.drawString(zoomMenu ? "On" : "Off", 40+x+(sx/2), 60+y, 4);
 }
 
@@ -1546,7 +1546,7 @@ static void drawInfo(int x, int y, int sx)
 
   // Info box
   spr.setTextDatum(ML_DATUM);
-  spr.setTextColor(TH.box_text, TH.box_bg);
+  spr.setTextColor(TH.box_text);
   spr.fillSmoothRoundRect(1+x, 1+y, 76+sx, 110, 4, TH.box_border);
   spr.fillSmoothRoundRect(2+x, 2+y, 74+sx, 108, 4, TH.box_bg);
 
@@ -1574,11 +1574,11 @@ static void drawInfo(int x, int y, int sx)
     spr.setTextColor(TH.box_off_text, TH.box_off_bg);
     sprintf(text, muteOn(MUTE_MAIN) ? "Muted" : "%d/sq", volume);
     spr.drawString(text, 48+x, 64+y+(0*16), 2);
-    spr.setTextColor(TH.box_text, TH.box_bg);
+    spr.setTextColor(TH.box_text);
   }
   else
   {
-    spr.setTextColor(TH.box_text, TH.box_bg);
+    spr.setTextColor(TH.box_text);
     spr.drawNumber(volume, 48+x, 64+y+(0*16), 2);
   }
 


### PR DESCRIPTION
This dramatically helps customization modding efforts (like setting a background image instead of a plain color, for example). As far as I know, it causes no graphical corruption, but I haven't thoroughly exhausted every single menu and interaction possible.